### PR TITLE
6. Регистрация зависимости Commands.Move в IoC.

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/MoveCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/MoveCommandTest.cs
@@ -68,14 +68,14 @@ public class RegisterIoCDependencyMoveCommandTest
         moving.SetupGet(m => m.Velocity).Returns(new Vector([-4, 1]));
 
         Ioc.Resolve<App.ICommand>(
-            "IoC.Register", 
-            "Adapters.IMovingObject", 
+            "IoC.Register",
+            "Adapters.IMovingObject",
             (object[] args) => moving.Object
         ).Execute();
 
         new RegisterIoCDependencyMoveCommand().Execute();
         var move = Ioc.Resolve<SpaceBattle.lib.ICommand>("Commands.Move", new object());
-        
+
         move.Execute();
 
         moving.VerifySet(m => m.Position = new Vector([8, 6]), Times.Once);

--- a/space-battle/SpaceBattle.Lib.Tests/MoveCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/MoveCommandTest.cs
@@ -2,6 +2,8 @@
 using Xunit;
 using Moq;
 using SpaceBattle.lib;
+using App.Scopes;
+using App;
 
 public class MoveCommandTests
 {
@@ -12,7 +14,7 @@ public class MoveCommandTests
         moving.SetupGet(a => a.Position).Returns(new Vector([12, 5]));
         moving.SetupGet(a => a.Velocity).Returns(new Vector([-4, 1]));
 
-        ICommand cmd = new MoveCommand(moving.Object);
+        SpaceBattle.lib.ICommand cmd = new MoveCommand(moving.Object);
         cmd.Execute();
 
         moving.VerifySet(a => a.Position = new Vector([8, 6]));
@@ -46,5 +48,36 @@ public class MoveCommandTests
         moving.SetupSet(a => a.Position = new Vector([8, 6])).Throws<InvalidOperationException>();
 
         Assert.Throws<InvalidOperationException>(() => new MoveCommand(moving.Object).Execute());
+    }
+}
+
+public class RegisterIoCDependencyMoveCommandTest
+{
+    public RegisterIoCDependencyMoveCommandTest()
+    {
+        new InitCommand().Execute();
+        var iocScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<App.ICommand>("IoC.Scope.Current.Set", iocScope).Execute();
+    }
+
+    [Fact]
+    public void General()
+    {
+        var moving = new Mock<IMovingObject>();
+        moving.SetupGet(m => m.Position).Returns(new Vector([12, 5]));
+        moving.SetupGet(m => m.Velocity).Returns(new Vector([-4, 1]));
+
+        Ioc.Resolve<App.ICommand>(
+            "IoC.Register", 
+            "Adapters.IMovingObject", 
+            (object[] args) => moving.Object
+        ).Execute();
+
+        new RegisterIoCDependencyMoveCommand().Execute();
+        var move = Ioc.Resolve<SpaceBattle.lib.ICommand>("Commands.Move", new object());
+        
+        move.Execute();
+
+        moving.VerifySet(m => m.Position = new Vector([8, 6]), Times.Once);
     }
 }

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyMoveCommand.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyMoveCommand.cs
@@ -1,0 +1,22 @@
+
+using App;
+
+namespace SpaceBattle.lib;
+
+public class RegisterIoCDependencyMoveCommand : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<App.ICommand>(
+            "IoC.Register",
+            "Commands.Move",
+            (object[] args) => 
+            {
+                var obj = args[0];
+
+                var movingObject = Ioc.Resolve<IMovingObject>("Adapters.IMovingObject", obj);
+                return new MoveCommand(movingObject);
+            }
+        ).Execute();
+    }
+}

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyMoveCommand.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyMoveCommand.cs
@@ -10,7 +10,7 @@ public class RegisterIoCDependencyMoveCommand : ICommand
         Ioc.Resolve<App.ICommand>(
             "IoC.Register",
             "Commands.Move",
-            (object[] args) => 
+            (object[] args) =>
             {
                 var obj = args[0];
 


### PR DESCRIPTION
### 6. Регистрация зависимости Commands.Move в IoC.
Зарегистрировать зависимость "Commands.Move" в IoC, с помощью которой можно разрешить команду MoveCommand по игровому объекту. Для регистрации зависимости определить отдельную команду с префиксом RegisterIoCDependency:

```
public class RegisterIoCDependencyMoveCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
```
**Примечание:** Для того, чтобы создать MoveCommand, необходимо создать адаптер IDictionary<string, object> для интерфейса IMovingObject. Задача конструирования Адаптеров по интерфейсу будет рассмотрена в другой лабораторной работе, поэтому в данной задаче используйте разрешение зависимости Ioc.Resolve("Adapters.IMovingObject", obj), где obj - игровой объект. В тестах используйте Mock-объекты, для разрешения этой зависимости.