### PR TITLE
9. Регистрация зависимости Commands.Rotate в IoC.

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/RotateCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/RotateCommandTest.cs
@@ -1,4 +1,6 @@
 
+using App;
+using App.Scopes;
 using Moq;
 using SpaceBattle.lib;
 using Xunit;
@@ -53,3 +55,37 @@ public class RotateTests
         Assert.Throws<Exception>(() => command.Execute());
     }
 }
+
+public class RegisterIoCDependencyRotateCommandTest
+{
+    public RegisterIoCDependencyRotateCommandTest()
+    {
+        new InitCommand().Execute();
+        var iocScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<App.ICommand>("IoC.Scope.Current.Set", iocScope).Execute();
+    }
+
+    [Fact]
+    public void RegisterRotate_ShouldAllowResolvingAndExecutingCommand()
+    {
+        var rotating = new Mock<IRotatableObject>();
+        rotating.SetupProperty(r => r.Angle, new Angle(1));
+        rotating.SetupGet(r => r.AngularVelocity).Returns(new Angle(1));
+
+        Ioc.Resolve<App.ICommand>(
+            "IoC.Register",
+            "Adapters.IRotatingObject",
+            (object[] args) => rotating.Object
+        ).Execute();
+
+        new RegisterIoCDependencyRotateCommand().Execute();
+
+        var rotateCmd = Ioc.Resolve<SpaceBattle.lib.ICommand>("Commands.Rotate", new object());
+
+        rotateCmd.Execute();
+
+        Assert.Equal(new Angle(2), rotating.Object.Angle);
+        rotating.VerifySet(r => r.Angle = new Angle(2), Times.Once);
+    }
+}
+

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyRotateCommand.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyRotateCommand.cs
@@ -1,0 +1,23 @@
+
+using App;
+
+namespace SpaceBattle.lib;
+
+public class RegisterIoCDependencyRotateCommand : lib.ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<App.ICommand>(
+            "IoC.Register",
+            "Commands.Rotate",
+            (object[] args) =>
+            {
+                var obj = args[0];
+
+                var rotatable = Ioc.Resolve<IRotatableObject>("Adapters.IRotatingObject", obj);
+
+                return new RotateCommand(rotatable);
+            }
+        ).Execute();
+    }
+}


### PR DESCRIPTION
### 9. Регистрация зависимости Commands.Rotate в IoC.
Зарегистрировать зависимость "Commands.Rotate" в IoC, с помощью которой можно разрешить команду MoveCommand по игровому объекту. Для регистрации зависимости определить отдельную команду с префиксом RegisterIoCDependency:

```
public class RegisterIoCDependencyRotateCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
```
**Примечание:** Для того, чтобы создать RotateCommand, необходимо создать адаптер IDictionary<string, object> для интерфейса IRotatingObject. Задача конструирования Адаптеров по интерфейсу будет рассмотрена в другой лабораторной работе, поэтому в данной задаче используйте разрешение зависимости Ioc.Resolve("Adapters.IRotatingObject", obj), где obj - игровой объект. В тестах используйте Mock-объекты, для разрешения этой зависимости.