### PR TITLE
10. Определить команду MacroCommand.

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/MacroCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/MacroCommandTest.cs
@@ -1,0 +1,40 @@
+
+using Xunit;
+using Moq;
+using SpaceBattle.lib;
+
+public class MacroCommandTest
+{
+    [Fact]
+    public void MacroCommand_RunsAll()
+    {
+        var cmd1 = new Mock<ICommand>();
+        var cmd2 = new Mock<ICommand>();
+        var cmd3 = new Mock<ICommand>();
+
+        ICommand macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
+
+        macro.Execute();
+
+        cmd1.Verify(c => c.Execute(), Times.Once());
+        cmd2.Verify(c => c.Execute(), Times.Once());
+        cmd3.Verify(c => c.Execute(), Times.Once());
+    }
+
+    [Fact]
+    public void MacroCommand_ThrowsException()
+    {
+        var cmd1 = new Mock<ICommand>();
+        var cmd2 = new Mock<ICommand>();
+        cmd2.Setup(cmd => cmd.Execute()).Throws<Exception>();
+        var cmd3 = new Mock<ICommand>();
+
+        ICommand macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
+
+        Assert.Throws<Exception>(() => macro.Execute());
+
+        cmd1.Verify(c => c.Execute(), Times.Once());
+        cmd2.Verify(c => c.Execute(), Times.Once());
+        cmd3.Verify(c => c.Execute(), Times.Never());
+    }
+}

--- a/space-battle/SpaceBattle.Lib/MacroCommand.cs
+++ b/space-battle/SpaceBattle.Lib/MacroCommand.cs
@@ -1,0 +1,12 @@
+
+namespace SpaceBattle.lib;
+
+public class MacroCommand(ICommand[] cmds) : ICommand
+{
+
+    readonly ICommand[] _cmds = cmds;
+    public void Execute()
+    {
+        _cmds.ToList().ForEach(cmd => cmd.Execute());
+    }
+}


### PR DESCRIPTION
### 10. Определить команду MacroCommand для выполнения последовательности команд.
MacroCommand в конструктор получает массив ICommand. Метод Execute последовательно выполняет все команды из массива.

**Критерии приемки:**

- Для реализации MacroCommand не используются циклы.
- Реализован тест "MacroCommand выполняет все команды из массива".
- Реализован тест, который проверяет, что MacroCommand.Execute выбрасывает исключение, если одна из команд выбрасывает исключение, оставшиеся команды не выполняются.