### PR TITLE
11. Определить зависимость "Commands.Macro" в IoC

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/MacroCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/MacroCommandTest.cs
@@ -14,7 +14,7 @@ public class MacroCommandTest
         var cmd2 = new Mock<SpaceBattle.lib.ICommand>();
         var cmd3 = new Mock<SpaceBattle.lib.ICommand>();
 
-        SpaceBattle.lib.ICommand macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
+        var macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
 
         macro.Execute();
 
@@ -31,7 +31,7 @@ public class MacroCommandTest
         cmd2.Setup(cmd => cmd.Execute()).Throws<Exception>();
         var cmd3 = new Mock<SpaceBattle.lib.ICommand>();
 
-        SpaceBattle.lib.ICommand macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
+        var macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
 
         Assert.Throws<Exception>(() => macro.Execute());
 
@@ -41,9 +41,9 @@ public class MacroCommandTest
     }
 }
 
-public class RegisterIoCDependencySendCommandTest
+public class RegisterIoCDependencyMacroCommandTest
 {
-    public RegisterIoCDependencySendCommandTest()
+    public RegisterIoCDependencyMacroCommandTest()
     {
         new InitCommand().Execute();
         var iocScope = Ioc.Resolve<object>("IoC.Scope.Create");

--- a/space-battle/SpaceBattle.Lib.Tests/MacroCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/MacroCommandTest.cs
@@ -2,17 +2,19 @@
 using Xunit;
 using Moq;
 using SpaceBattle.lib;
+using App;
+using App.Scopes;
 
 public class MacroCommandTest
 {
     [Fact]
     public void MacroCommand_RunsAll()
     {
-        var cmd1 = new Mock<ICommand>();
-        var cmd2 = new Mock<ICommand>();
-        var cmd3 = new Mock<ICommand>();
+        var cmd1 = new Mock<SpaceBattle.lib.ICommand>();
+        var cmd2 = new Mock<SpaceBattle.lib.ICommand>();
+        var cmd3 = new Mock<SpaceBattle.lib.ICommand>();
 
-        ICommand macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
+        SpaceBattle.lib.ICommand macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
 
         macro.Execute();
 
@@ -24,17 +26,44 @@ public class MacroCommandTest
     [Fact]
     public void MacroCommand_ThrowsException()
     {
-        var cmd1 = new Mock<ICommand>();
-        var cmd2 = new Mock<ICommand>();
+        var cmd1 = new Mock<SpaceBattle.lib.ICommand>();
+        var cmd2 = new Mock<SpaceBattle.lib.ICommand>();
         cmd2.Setup(cmd => cmd.Execute()).Throws<Exception>();
-        var cmd3 = new Mock<ICommand>();
+        var cmd3 = new Mock<SpaceBattle.lib.ICommand>();
 
-        ICommand macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
+        SpaceBattle.lib.ICommand macro = new MacroCommand([cmd1.Object, cmd2.Object, cmd3.Object]);
 
         Assert.Throws<Exception>(() => macro.Execute());
 
         cmd1.Verify(c => c.Execute(), Times.Once());
         cmd2.Verify(c => c.Execute(), Times.Once());
         cmd3.Verify(c => c.Execute(), Times.Never());
+    }
+}
+
+public class RegisterIoCDependencySendCommandTest
+{
+    public RegisterIoCDependencySendCommandTest()
+    {
+        new InitCommand().Execute();
+        var iocScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<App.ICommand>("IoC.Scope.Current.Set", iocScope).Execute();
+    }
+
+    [Fact]
+    public void General()
+    {
+        var cmd1 = new Mock<SpaceBattle.lib.ICommand>();
+        var cmd2 = new Mock<SpaceBattle.lib.ICommand>();
+        var cmd3 = new Mock<SpaceBattle.lib.ICommand>();
+
+        new RegisterIoCDependencyMacroCommand().Execute();
+
+        var macro = Ioc.Resolve<SpaceBattle.lib.ICommand>("Commands.MacroCommand", new SpaceBattle.lib.ICommand[] { cmd1.Object, cmd2.Object, cmd3.Object });
+        macro.Execute();
+
+        cmd1.Verify(c => c.Execute(), Times.Once());
+        cmd2.Verify(c => c.Execute(), Times.Once());
+        cmd3.Verify(c => c.Execute(), Times.Once());
     }
 }

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyMacroCommand.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyMacroCommand.cs
@@ -1,0 +1,15 @@
+
+using App;
+namespace SpaceBattle.lib;
+
+public class RegisterIoCDependencyMacroCommand : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<App.ICommand>(
+            "IoC.Register",
+            "Commands.MacroCommand",
+            (object[] args) => new MacroCommand((ICommand[])args)
+        ).Execute();
+    }
+}


### PR DESCRIPTION
11. Определить зависимость "Commands.Macro" в IoC, которая по массиву команд возвращает Макрокоманду.
Указание: Для регистрации зависимости определить команду RegisterIoCDependencyMacroCommand:

```
public class RegisterIoCDependencyMacroCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
```
**Критерии приемки:**

Реализован тест, который проверяет, что при выполнении Execute класса RegisterDependencyMacroCommand зависимость разрешается.