### PR TITLE
13. Регистрация зависимостей "Macro.Move" и "Macro.Rotate" в IoC.

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/RegisterMacroMoveRotateTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/RegisterMacroMoveRotateTest.cs
@@ -1,0 +1,43 @@
+
+using App;
+using App.Scopes;
+using Moq;
+using SpaceBattle.lib;
+using Xunit;
+
+public class RegisterMacroMoveRotateTests
+{
+    public RegisterMacroMoveRotateTests()
+    {
+        new InitCommand().Execute();
+        var iocScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<App.ICommand>("IoC.Scope.Current.Set", iocScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_RegistersMacroMoveAndRotate_BothWork()
+    {
+        var moveCmd = new Mock<SpaceBattle.lib.ICommand>();
+        var rotateCmd = new Mock<SpaceBattle.lib.ICommand>();
+        var targetObject = new object();
+
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Specs.Move", (object[] args) =>
+            new List<string> { "Command.MoveDoDep" }).Execute();
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Command.MoveDoDep", (object[] args) => moveCmd.Object).Execute();
+
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Specs.Rotate", (object[] args) =>
+            new List<string> { "Command.RotateDoDep" }).Execute();
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Command.RotateDoDep", (object[] args) => rotateCmd.Object).Execute();
+
+        new RegisterIoCDependencyMacroMoveRotate().Execute();
+
+        var macroMove = Ioc.Resolve<SpaceBattle.lib.ICommand>("Macro.Move", targetObject);
+        macroMove.Execute();
+
+        var macroRotate = Ioc.Resolve<SpaceBattle.lib.ICommand>("Macro.Rotate", targetObject);
+        macroRotate.Execute();
+
+        moveCmd.Verify(m => m.Execute(), Times.Once());
+        rotateCmd.Verify(m => m.Execute(), Times.Once());
+    }
+}

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyMacroMoveRotate.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyMacroMoveRotate.cs
@@ -1,0 +1,22 @@
+
+using App;
+
+namespace SpaceBattle.lib;
+
+public class RegisterIoCDependencyMacroMoveRotate : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<App.ICommand>(
+            "IoC.Register",
+            "Macro.Move",
+            (object[] args) => new CreateMacroCommandStrategy("Specs.Move").Resolve(args)
+        ).Execute();
+
+        Ioc.Resolve<App.ICommand>(
+            "IoC.Register",
+            "Macro.Rotate",
+            (object[] args) => new CreateMacroCommandStrategy("Specs.Rotate").Resolve(args)
+        ).Execute();
+    }
+}


### PR DESCRIPTION
### 13. Регистрация зависимостей "Macro.Move" и "Macro.Rotate" в IoC.
Примечание: Считать, что зависимости "Specs.Move" и "Specs.Rotate" - заданы (это другая лабораторная работа). Для тестов задать зависимости с помощью Mock-объектов.

**Указание:** Для регистрации зависимости определить команду RegisterIoCDependencyMacroMoveRotate:

```
public class RegisterIoCDependencyMacroMoveRotate : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
```