### PR TITLE
14. Определить команду SendCommand для отправки команды.

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/SendCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/SendCommandTest.cs
@@ -1,0 +1,30 @@
+
+using Xunit;
+using Moq;
+using SpaceBattle.lib;
+
+public class SendCommandTest
+{
+    [Fact]
+    public void SendCommandTransfersCommandToReceiver()
+    {
+        var cmd = new Mock<ICommand>();
+        var receiver = new Mock<ICommandReceiver>();
+        var sendCommand = new SendCommand(cmd.Object, receiver.Object);
+
+        sendCommand.Execute();
+        receiver.Verify(r => r.Receive(cmd.Object), Times.Once);
+    }
+
+    [Fact]
+    public void ReceiverCantAcceptCommandThrowsException()
+    {
+        var cmd = new Mock<ICommand>();
+        var receiver = new Mock<ICommandReceiver>();
+        receiver.Setup(r => r.Receive(It.IsAny<ICommand>())).Throws<Exception>();
+
+        var sendCommand = new SendCommand(cmd.Object, receiver.Object);
+
+        Assert.Throws<Exception>(() => sendCommand.Execute());
+    }
+}

--- a/space-battle/SpaceBattle.Lib/ICommandReceiver.cs
+++ b/space-battle/SpaceBattle.Lib/ICommandReceiver.cs
@@ -1,0 +1,7 @@
+
+namespace SpaceBattle.lib;
+
+public interface ICommandReceiver
+{
+    void Receive(ICommand cmd);
+}

--- a/space-battle/SpaceBattle.Lib/SendCommand.cs
+++ b/space-battle/SpaceBattle.Lib/SendCommand.cs
@@ -1,0 +1,10 @@
+
+namespace SpaceBattle.lib;
+
+public class SendCommand(ICommand sendingCommand, ICommandReceiver receiver) : ICommand
+{
+    public void Execute()
+    {
+        receiver.Receive(sendingCommand);
+    }
+}


### PR DESCRIPTION
### 14. Определить команду SendCommand для отправки команды.
SendCommand в конструктор получает команду ICommand и интерфейс ICommandReceiver. В методе Execute SendCommand вызывается метод Receive интерфейса ICommandReceiver, в который передается длительная команда.

**Критерии приемки:**

Реализован тест "SendCommand передает команду в IMessageReceiver", который проверяет, что при вызове метода Execute класса SendCommand вызывается метод Receive объекта ICommandReceiver с параметром - объектом длительной команды.
Реализован тест, который проверяет, что SendCommand.Execute выбрасывает исключение, если IMessageReceiver не может принять длительную команду.