### PR TITLE
17. Определить команду CommandInjectableCommand

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/CommandInjectableCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/CommandInjectableCommandTest.cs
@@ -1,0 +1,38 @@
+
+using Xunit;
+using Moq;
+using SpaceBattle.lib;
+public class CommandInjectableCommandTests
+{
+    [Fact]
+    public void CommandExecutingAfterInjection()
+    {
+        var cmd1 = new Mock<ICommand>();
+        var cmd2 = new Mock<ICommand>();
+        var injectable = new CommandInjectableCommand(cmd1.Object);
+
+        injectable.Execute();
+        injectable.Inject(cmd2.Object);
+        injectable.Execute();
+
+        cmd1.Verify(c => c.Execute(), Times.Once);
+        cmd2.Verify(c => c.Execute(), Times.Once);
+    }
+
+    [Fact]
+    public void CommandInjectableCommandThrowsExceptionIfCommandWasNotInjected()
+    {
+        var injectable = new CommandInjectableCommand(null);
+
+        Assert.Throws<InvalidOperationException>(() => injectable.Execute());
+    }
+
+    [Fact]
+    public void CommandInjectableCommandThrowsExceptionIfInjectedNull()
+    {
+        var cmd = new Mock<ICommand>();
+        var injectable = new CommandInjectableCommand(cmd.Object);
+
+        Assert.Throws<ArgumentNullException>(() => injectable.Inject(null));
+    }
+}

--- a/space-battle/SpaceBattle.Lib/CommandInjectableCommand.cs
+++ b/space-battle/SpaceBattle.Lib/CommandInjectableCommand.cs
@@ -1,0 +1,17 @@
+
+namespace SpaceBattle.lib;
+
+public class CommandInjectableCommand(ICommand? cmd) : ICommand, ICommandInjectable
+{
+    private ICommand? _command = cmd;
+    public void Execute()
+    {
+        if (_command == null) throw new InvalidOperationException("Команда не внедрена.");
+        _command.Execute();
+    }
+
+    public void Inject(ICommand? command)
+    {
+        _command = command ?? throw new ArgumentNullException(nameof(command));
+    }
+}


### PR DESCRIPTION
### 17. Определить команду CommandInjectableCommand
Команда реализует два интерфейса ICommand и ICommandIjectable.

**Критерии приемки:**

- Реализован тест, который проверяет, что после того как команда будет внедрена в объект класса CommandInjectableCommand, то она будет вызвана при выполнении метода Execute объекта класса CommandInjectableCommand.
- Реализован тест, который проверяет, что вызов Execute класса CommandInjectableCommand выбрасывает исключение, если не была внедерена команда.