### PR TITLE
18. Определить зависимость "Commands.CommandInjectable" в IoC, которая конструирует команду CommandInjectableCommand.

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/CommandInjectableCommandTest.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/CommandInjectableCommandTest.cs
@@ -1,14 +1,16 @@
 
 using Xunit;
 using Moq;
+using App;
 using SpaceBattle.lib;
+using App.Scopes;
 public class CommandInjectableCommandTests
 {
     [Fact]
     public void CommandExecutingAfterInjection()
     {
-        var cmd1 = new Mock<ICommand>();
-        var cmd2 = new Mock<ICommand>();
+        var cmd1 = new Mock<SpaceBattle.lib.ICommand>();
+        var cmd2 = new Mock<SpaceBattle.lib.ICommand>();
         var injectable = new CommandInjectableCommand(cmd1.Object);
 
         injectable.Execute();
@@ -30,9 +32,57 @@ public class CommandInjectableCommandTests
     [Fact]
     public void CommandInjectableCommandThrowsExceptionIfInjectedNull()
     {
-        var cmd = new Mock<ICommand>();
+        var cmd = new Mock<SpaceBattle.lib.ICommand>();
         var injectable = new CommandInjectableCommand(cmd.Object);
 
         Assert.Throws<ArgumentNullException>(() => injectable.Inject(null));
+    }
+}
+
+public class RegisterDependencyCommandInjectableCommandTest
+{
+    public RegisterDependencyCommandInjectableCommandTest()
+    {
+        new InitCommand().Execute();
+        var iocScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<App.ICommand>("IoC.Scope.Current.Set", iocScope).Execute();
+    }
+
+    [Fact]
+    public void General()
+    {
+        var cmd1 = new Mock<SpaceBattle.lib.ICommand>();
+        var cmd2 = new Mock<SpaceBattle.lib.ICommand>();
+
+        new RegisterDependencyCommandInjectableCommand().Execute();
+
+        var injectable = Ioc.Resolve<ICommandInjectable>("Commands.CommandInjectable", cmd1.Object);
+        ((SpaceBattle.lib.ICommand)injectable).Execute();
+
+        cmd1.Verify(c => c.Execute(), Times.Once);
+
+        injectable.Inject(cmd2.Object);
+
+        ((SpaceBattle.lib.ICommand)injectable).Execute();
+
+        cmd1.Verify(c => c.Execute(), Times.Once);
+        cmd2.Verify(c => c.Execute(), Times.Once);
+    }
+
+    [Fact]
+    public void ShouldResolveAsMultipleTypesWithoutException()
+    {
+        new RegisterDependencyCommandInjectableCommand().Execute();
+        var mockCmd = new Mock<SpaceBattle.lib.ICommand>().Object;
+
+
+        var icmd = Ioc.Resolve<SpaceBattle.lib.ICommand>("Commands.CommandInjectable", mockCmd);
+        Assert.NotNull(icmd);
+
+        var injc = Ioc.Resolve<ICommandInjectable>("Commands.CommandInjectable", mockCmd);
+        Assert.NotNull(injc);
+
+        var cmd = Ioc.Resolve<CommandInjectableCommand>("Commands.CommandInjectable", mockCmd);
+        Assert.NotNull(cmd);
     }
 }

--- a/space-battle/SpaceBattle.Lib/RegisterDependencyCommandInjectableCommand.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterDependencyCommandInjectableCommand.cs
@@ -1,0 +1,15 @@
+
+using App;
+namespace SpaceBattle.lib;
+
+public class RegisterDependencyCommandInjectableCommand : ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<App.ICommand>(
+            "IoC.Register",
+            "Commands.CommandInjectable",
+            (object[] args) => new CommandInjectableCommand((ICommand)args[0])
+        ).Execute();
+    }
+}


### PR DESCRIPTION
### 18. Определить зависимость "Commands.CommandInjectable" в IoC, которая конструирует команду CommandInjectableCommand.
**Указание:** Для регистрации зависимости определить команду RegisterMacroCommand:

```
public class RegisterDependencyCommandInjectableCommand : ICommand
{
    public void Execute()
  {
      // код, регистрирующий зависимость
    }
}
```

**Критерии приемки:**

Реализован тест, который проверяет, что следующий код работает без выброса исключений:
Ioc.Resolve<ICommand>("Commands.CommadInjectable");
Ioc.Resolve<ICommandInjectable>("Commands.CommadInjectable");
Ioc.Resolve<CommandInjectableCommand>("Commands.CommadInjectable");