### PR TITLE
19. Определить зависимость "Actions.Start" для запуска длительной операции

### DIFF
--- a/space-battle/SpaceBattle.Lib.Tests/RegisterIoCDependencyActionsStartTests.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/RegisterIoCDependencyActionsStartTests.cs
@@ -63,4 +63,28 @@ public class RegisterIoCDependencyActionsStartTests
         operation.Verify(op => op.Execute(), Times.Once);
         receiver.Verify(r => r.Receive(It.Is<SpaceBattle.lib.ICommand>(c => ReferenceEquals(c, startCommand))), Times.Once);
     }
+
+    [Fact]
+    public void Execute_ShouldPutStartCommandInActiveOperationsByTarget()
+    {
+        var operation = new Mock<SpaceBattle.lib.ICommand>();
+        var receiver = new Mock<SpaceBattle.lib.ICommandReceiver>();
+        var targetObject = new object();
+
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Move", (object[] args) => operation.Object).Execute();
+        new SpaceBattle.lib.RegisterIoCDependencyActionsStart().Execute();
+        var activeOperations = Ioc.Resolve<IDictionary<object, SpaceBattle.lib.ICommand>>("Actions.ActiveOperations");
+
+        IDictionary<string, object> order = new Dictionary<string, object>
+        {
+            { "target", targetObject },
+            { "command", "Move" },
+            { "receiver", receiver.Object },
+        };
+
+        var startCommand = Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.Start", order);
+
+        Assert.True(activeOperations.TryGetValue(targetObject, out var activeCommand));
+        Assert.Same(startCommand, activeCommand);
+    }
 }

--- a/space-battle/SpaceBattle.Lib.Tests/RegisterIoCDependencyActionsStartTests.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/RegisterIoCDependencyActionsStartTests.cs
@@ -1,0 +1,35 @@
+
+using App;
+using App.Scopes;
+using Moq;
+using System.Collections.Generic;
+using Xunit;
+
+public class RegisterIoCDependencyActionsStartTests
+{
+    public RegisterIoCDependencyActionsStartTests()
+    {
+        new InitCommand().Execute();
+        var iocScope = Ioc.Resolve<object>("IoC.Scope.Create");
+        Ioc.Resolve<App.ICommand>("IoC.Scope.Current.Set", iocScope).Execute();
+    }
+
+    [Fact]
+    public void Execute_ShouldRegisterActionsStart_AndResolveSuccessfully()
+    {
+        var registration = new SpaceBattle.lib.RegisterIoCDependencyActionsStart();
+
+        registration.Execute();
+
+        IDictionary<string, object> order = new Dictionary<string, object>
+        {
+            { "target", new object() },
+            { "command", "Move" }
+        };
+
+        var command = Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.Start", order);
+
+        Assert.NotNull(command);
+        Assert.IsType<SpaceBattle.lib.ActionStartCommand>(command);
+    }
+}

--- a/space-battle/SpaceBattle.Lib.Tests/RegisterIoCDependencyActionsStartTests.cs
+++ b/space-battle/SpaceBattle.Lib.Tests/RegisterIoCDependencyActionsStartTests.cs
@@ -17,19 +17,50 @@ public class RegisterIoCDependencyActionsStartTests
     [Fact]
     public void Execute_ShouldRegisterActionsStart_AndResolveSuccessfully()
     {
+        var operation = new Mock<SpaceBattle.lib.ICommand>();
+        var receiver = new Mock<SpaceBattle.lib.ICommandReceiver>();
+        var targetObject = new object();
+
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Move", (object[] args) => operation.Object).Execute();
+
         var registration = new SpaceBattle.lib.RegisterIoCDependencyActionsStart();
 
         registration.Execute();
 
         IDictionary<string, object> order = new Dictionary<string, object>
         {
-            { "target", new object() },
-            { "command", "Move" }
+            { "target", targetObject },
+            { "command", "Move" },
+            { "receiver", receiver.Object },
         };
 
         var command = Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.Start", order);
 
         Assert.NotNull(command);
         Assert.IsType<SpaceBattle.lib.ActionStartCommand>(command);
+    }
+
+    [Fact]
+    public void ActionStartCommand_ExecutesOperation_AndEnqueuesItself()
+    {
+        var operation = new Mock<SpaceBattle.lib.ICommand>();
+        var receiver = new Mock<SpaceBattle.lib.ICommandReceiver>();
+        var targetObject = new object();
+
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Move", (object[] args) => operation.Object).Execute();
+        new SpaceBattle.lib.RegisterIoCDependencyActionsStart().Execute();
+
+        IDictionary<string, object> order = new Dictionary<string, object>
+        {
+            { "target", targetObject },
+            { "command", "Move" },
+            { "receiver", receiver.Object },
+        };
+
+        var startCommand = Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.Start", order);
+        startCommand.Execute();
+
+        operation.Verify(op => op.Execute(), Times.Once);
+        receiver.Verify(r => r.Receive(It.Is<SpaceBattle.lib.ICommand>(c => ReferenceEquals(c, startCommand))), Times.Once);
     }
 }

--- a/space-battle/SpaceBattle.Lib/ActionStartCommand.cs
+++ b/space-battle/SpaceBattle.Lib/ActionStartCommand.cs
@@ -3,10 +3,22 @@ namespace SpaceBattle.lib;
 
 public class ActionStartCommand : SpaceBattle.lib.ICommand
 {
-    public ActionStartCommand(params object[] args) { }
+    private readonly ICommand _longRunningOperation;
+    private readonly ICommandReceiver _receiver;
+
+    public ActionStartCommand(ICommand longRunningOperation, ICommandReceiver receiver)
+    {
+        _longRunningOperation = longRunningOperation;
+        _receiver = receiver;
+    }
 
     public void Execute()
     {
-
+        new MacroCommand(
+            [
+                _longRunningOperation,
+                new SendCommand(this, _receiver),
+            ]
+        ).Execute();
     }
 }

--- a/space-battle/SpaceBattle.Lib/ActionStartCommand.cs
+++ b/space-battle/SpaceBattle.Lib/ActionStartCommand.cs
@@ -1,0 +1,12 @@
+
+namespace SpaceBattle.lib;
+
+public class ActionStartCommand : SpaceBattle.lib.ICommand
+{
+    public ActionStartCommand(params object[] args) { }
+
+    public void Execute()
+    {
+
+    }
+}

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyActionsActiveOperations.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyActionsActiveOperations.cs
@@ -1,0 +1,17 @@
+using App;
+using System.Collections.Generic;
+
+namespace SpaceBattle.lib;
+
+public class RegisterIoCDependencyActionsActiveOperations : SpaceBattle.lib.ICommand
+{
+    public void Execute()
+    {
+        var activeOperations = new Dictionary<object, SpaceBattle.lib.ICommand>();
+
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Actions.ActiveOperations", (object[] args) =>
+        {
+            return activeOperations;
+        }).Execute();
+    }
+}

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyActionsStart.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyActionsStart.cs
@@ -1,0 +1,25 @@
+
+using App;
+using System.Collections.Generic;
+
+namespace SpaceBattle.lib;
+
+public class RegisterIoCDependencyActionsStart : SpaceBattle.lib.ICommand
+{
+    public void Execute()
+    {
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Actions.StartCommand", (object[] args) =>
+        {
+            return new ActionStartCommand(args);
+        }).Execute();
+
+        Ioc.Resolve<App.ICommand>("IoC.Register", "Actions.Start", (object[] args) =>
+        {
+            var order = (IDictionary<string, object>)args[0];
+            var target = order["target"];
+            var command = (string)order["command"];
+
+            return Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.StartCommand", target, command);
+        }).Execute();
+    }
+}

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyActionsStart.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyActionsStart.cs
@@ -8,9 +8,12 @@ public class RegisterIoCDependencyActionsStart : SpaceBattle.lib.ICommand
 {
     public void Execute()
     {
+        new RegisterIoCDependencyMacroCommand().Execute();
+        new RegisterIoCDependencySendCommand().Execute();
+
         Ioc.Resolve<App.ICommand>("IoC.Register", "Actions.StartCommand", (object[] args) =>
         {
-            return new ActionStartCommand(args);
+            return new ActionStartCommand((SpaceBattle.lib.ICommand)args[0], (ICommandReceiver)args[1]);
         }).Execute();
 
         Ioc.Resolve<App.ICommand>("IoC.Register", "Actions.Start", (object[] args) =>
@@ -18,8 +21,10 @@ public class RegisterIoCDependencyActionsStart : SpaceBattle.lib.ICommand
             var order = (IDictionary<string, object>)args[0];
             var target = order["target"];
             var command = (string)order["command"];
+            var receiver = (ICommandReceiver)order["receiver"];
+            var longRunningOperation = Ioc.Resolve<SpaceBattle.lib.ICommand>(command, target);
 
-            return Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.StartCommand", target, command);
+            return Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.StartCommand", longRunningOperation, receiver);
         }).Execute();
     }
 }

--- a/space-battle/SpaceBattle.Lib/RegisterIoCDependencyActionsStart.cs
+++ b/space-battle/SpaceBattle.Lib/RegisterIoCDependencyActionsStart.cs
@@ -10,6 +10,7 @@ public class RegisterIoCDependencyActionsStart : SpaceBattle.lib.ICommand
     {
         new RegisterIoCDependencyMacroCommand().Execute();
         new RegisterIoCDependencySendCommand().Execute();
+        new RegisterIoCDependencyActionsActiveOperations().Execute();
 
         Ioc.Resolve<App.ICommand>("IoC.Register", "Actions.StartCommand", (object[] args) =>
         {
@@ -23,8 +24,11 @@ public class RegisterIoCDependencyActionsStart : SpaceBattle.lib.ICommand
             var command = (string)order["command"];
             var receiver = (ICommandReceiver)order["receiver"];
             var longRunningOperation = Ioc.Resolve<SpaceBattle.lib.ICommand>(command, target);
+            var activeOperations = Ioc.Resolve<IDictionary<object, SpaceBattle.lib.ICommand>>("Actions.ActiveOperations");
+            var startCommand = Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.StartCommand", longRunningOperation, receiver);
 
-            return Ioc.Resolve<SpaceBattle.lib.ICommand>("Actions.StartCommand", longRunningOperation, receiver);
+            activeOperations[target] = startCommand;
+            return startCommand;
         }).Execute();
     }
 }


### PR DESCRIPTION
### 19. Определить зависимость "Actions.Start" для запуска длительной операции.
Необходимо так определить зависимость, чтобы следующий код позволял получать команду:

```
IDictionary<string, object> order = ...; // приказ о старте длительной операции
Ioc.Resolve<ICommand>("Actions.Start", order);
```

Сама регистрация зависимости должна быть выполнена в команде RegisterIoCDepenedncyActionsStart

```
public class RegisterIoCDependencyActionsStart : ICommand
{
    public void Execute()
  {
    // здесь код для регистрации зависимостей
  }
}
```
**Примечание:** Все дополнительные зависимости, которые будут использованы при реализации, кроме зависимостей, которые были оговорены выше, должны быть также зарегистрированы.